### PR TITLE
Allow http 8.x to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "discord/interactions": "^1|^2",
         "simplito/elliptic-php": "^1",
-        "discord-php/http": "^8"
+        "discord-php/http": "^8|^9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Resolves a conflict with Composer and the current dev-main of the main DiscordPHP branch