### PR TITLE
Fix deprecation warning in PHP 8.1

### DIFF
--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -80,8 +80,7 @@ class Part implements JsonSerializable
      *
      * @return array
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->attributes;
     }

--- a/src/Discord/Parts/Part.php
+++ b/src/Discord/Parts/Part.php
@@ -80,6 +80,7 @@ class Part implements JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->attributes;


### PR DESCRIPTION
Backwards-compatible deprecation warning fix for PHP 8.1, see https://wiki.php.net/rfc/internal_method_return_types:

```
Deprecated: Return type of Discord\Slash\Parts\Part::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in src/Discord/Parts/Part.php on line 83
```